### PR TITLE
Require Node.js 6 and replace fs-extra with make-dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
 - '6'
 - '8'
+- '10'
 
 branches:
   only:

--- a/index.js
+++ b/index.js
@@ -1,16 +1,26 @@
 'use strict';
 
-const fs = require('fs-extra');
+const fs = require('fs');
+const path = require('path');
+const makeDir = require('make-dir');
 const esprima = require('esprima');
 const util = require('util');
 const stringifyObject = require("stringify-object");
 
 const noop = function(){};
 
+function outputFileSync (filePath, contents, fileSystem = fs) {
+  const dir = path.dirname(filePath);
+  makeDir.sync(dir, {
+    fs: fileSystem
+  });
+  fileSystem.writeFileSync(filePath, contents);
+}
+
 class ConfigFile {
-  constructor(filePath, fileSystem = undefined) {
+  constructor(filePath, fileSystem = fs) {
     this.filePath = filePath;
-    this.fileSystem = fileSystem || fs;
+    this.fileSystem = fileSystem;
     this.config = null;
 
     /**
@@ -104,7 +114,7 @@ class ConfigFile {
       contents = this.contents.substring(0, this.range[0]) + this.buildConfig() + this.contents.substring(this.range[1]);
     }
 
-    this.fileSystem.outputFileSync(this.filePath, contents);
+    outputFileSync(this.filePath, contents, this.fileSystem);
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -122,8 +122,8 @@ class ConfigFile {
    *
    * notice: you still need to write() it to have a physical existing file.
    */
-  createIfNotExists(config) {
-    this.config = config || {};
+  createIfNotExists(config = {}) {
+    this.config = config;
     this.type = 'create-if-not-exists';
   }
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/webforge-labs/requirejs-config-file/issues"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=6.0.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -24,16 +24,17 @@
   },
   "devDependencies": {
     "chai": "^4.1.2",
+    "fs-extra": "^7.0.1",
     "grunt": "^1.0.1",
     "grunt-contrib-jshint": "^1.1.0",
     "grunt-simple-mocha": "~0.4.0",
     "matchdep": "^2.0.0",
-    "unionfs": "^3.0.2",
-    "memfs": "^2.14.1"
+    "memfs": "^2.14.1",
+    "unionfs": "^3.0.2"
   },
   "dependencies": {
     "esprima": "^4.0.0",
-    "fs-extra": "^5.0.0",
+    "make-dir": "^2.1.0",
     "stringify-object": "^3.2.1"
   }
 }


### PR DESCRIPTION
Dropping `fs-extra` has a couple of advantages

- make-dir is a much smaller dependency (with one fewer dependencies of its own)
- make-dir use the native method to create recursive directories on Node.js > 10.12
- The method `outputFileSync` of `fs-extra` is not part of `fs`. Anyone passing a custom filesystem to this module would have had to add this method. With this PR things just work.

I left `fs-extra` in the dev dependencies, it doesn't hurt anyone in the tests.